### PR TITLE
rc2014: convert del to backspace when reading tty

### DIFF
--- a/rc2014.c
+++ b/rc2014.c
@@ -439,6 +439,8 @@ unsigned int next_char(void)
 	}
 	if (c == 0x0A)
 		c = '\r';
+	else if (c == 0x7F)
+		c = '\b';
 	return c;
 }
 


### PR DESCRIPTION
To work with CP/M out-of-the-box it worth to convert modern 0x7F (DEL) to Backspace automatically. Will it break something?

(may it would be better to move tty read/write and char translation to some common file?)