### PR TITLE
duart.c: Fixes to allow port B as console.

### DIFF
--- a/duart.c
+++ b/duart.c
@@ -81,7 +81,7 @@ static void duart_output(struct duart *d, int port, int value)
 	if (d->port[port].txdis)
 		return;
 	if (d->port[port].sr & 0x04) {
-		if (port == 0) {
+		if (d->input - 1 == port) {
 			uint8_t v = value & 0xFF;
 			write(1, &v, 1);
 		}
@@ -156,12 +156,12 @@ static void duart_count(struct duart *d, int n)
 void duart_tick(struct duart *d)
 {
 	uint8_t r = check_chario();
-	if ((r & 1) && d->port[0].rxdis == 0) {
-	        if (d->input == 1) {
+	if (r & 1) {
+		if (d->input == 1 && d->port[0].rxdis == 0) {
 		    d->port[0].rx = next_char();
 		    d->port[0].sr |= 0x01;
 		    duart_irq_raise(d, 0x02);
-                } else if (d->input == 2) {
+                } else if (d->input == 2 && d->port[1].rxdis == 0) {
 		    d->port[1].rx = next_char();
 		    d->port[1].sr |= 0x01;
 		    duart_irq_raise(d, 0x20);


### PR DESCRIPTION
I'm working on porting EmuTOS to the Tiny68K. I've a desire to use DUART port B as the console so that port A is available for file transfers as it supports flow control and port B does not (as implemented on the Tiny68K). You've allowed for changing the console port, and this commit makes a couple of tweaks to that:

- In duart_output, don't hardcode port 0 as stdout source.
- In duart_tick, consider rxdis on per-port basis.
- Rename duart->input to hopefully more descriptive duart->console_port.

Thanks!
