### PR TITLE
2063: joystick structure was not always initialized during add

### DIFF
--- a/joystick.c
+++ b/joystick.c
@@ -107,11 +107,12 @@ void joystick_add(int index)
 
 	if (js == NULL) {
 		js = js_find(-1);
-		if (js != NULL) {
-			js->instance_id = id;
-			js->controller = c;
-			js->button_mask = 0xFF;
-		}
+	}
+
+	if (js != NULL) {
+		js->instance_id = id;
+		js->controller = c;
+		js->button_mask = 0xFF;
 	}
 }
 


### PR DESCRIPTION
causing joystick_read to return zero based button mask.