### PR TITLE
Add void to function declaration.

### DIFF
--- a/m68k/m68kcpu.c
+++ b/m68k/m68kcpu.c
@@ -817,7 +817,7 @@ void m68k_pulse_halt(void)
 
 /* Get and set the current CPU context */
 /* This is to allow for multiple CPUs */
-unsigned int m68k_context_size()
+unsigned int m68k_context_size(void)
 {
 	return sizeof(m68ki_cpu_core);
 }


### PR DESCRIPTION
A missing (void) is tripping up clang 15 when compiling for tiny68k:

```
m68kcpu.c:820:31: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]
unsigned int m68k_context_size()
                              ^
                               void
```