### PR TITLE
Delete gcc dependency.

### DIFF
--- a/lib65c816/config.mk
+++ b/lib65c816/config.mk
@@ -1,6 +1,5 @@
-CC      := gcc
 CCFLAGS := -c -O2 -fomit-frame-pointer $(CCOPTS) -DDEBUG -Werror
-LD      := gcc
+LD      := $(CC)
 LDFLAGS :=
 
 PREFIX  := /opt/v65c816/

--- a/libz180/codegen/Makefile
+++ b/libz180/codegen/Makefile
@@ -1,7 +1,7 @@
 all: mktables
 
 mktables: mktables.c
-	gcc -g -o mktables mktables.c
+	$(CC) -g -o mktables mktables.c
 	
 force: clean opcodes
 	

--- a/libz80/codegen/Makefile
+++ b/libz80/codegen/Makefile
@@ -1,7 +1,7 @@
 all: mktables
 
 mktables: mktables.c
-	gcc -g -o mktables mktables.c
+	$(CC) -g -o mktables mktables.c
 	
 force: clean opcodes
 	

--- a/m68k/Makefile
+++ b/m68k/Makefile
@@ -9,7 +9,6 @@ MUSASHIGENERATOR = m68kmake
 .CFILEST   = $(MUSASHIFILES) $(MUSASHIGENCFILES)
 .OFILEST   = $(.CFILEST:%.c=%.o)
 
-CC        = gcc -O2
 WARNINGS  = -Wall -pedantic -Werror
 CFLAGS    = $(WARNINGS)
 LFLAGS    = $(WARNINGS)


### PR DESCRIPTION
The system such like FreeBSD, no more use gcc as default.
So the compiler must specify no gcc directly but $(CC) macro.