### PR TITLE
rcbus-6809.c: mask off extra bits in PC.

### DIFF
--- a/rcbus-6809.c
+++ b/rcbus-6809.c
@@ -414,8 +414,13 @@ void e6809_instruction(unsigned pc)
 	char buf[80];
 	struct reg6809 *r = e6809_get_regs();
 	if (trace & TRACE_CPU) {
-		d6809_disassemble(buf, pc);
-		fprintf(stderr, "%04X: %-16.16s | ", pc, buf);
+                /*
+                 * The PC reported by e6809 can have garbage in the upper
+                 * bits of the value. Mask it off.
+                 */
+                unsigned dpc = pc & 0xFFFF;
+		d6809_disassemble(buf, dpc);
+		fprintf(stderr, "%04X: %-16.16s | ", dpc, buf);
 		fprintf(stderr, "%s %02X:%02X %04X %04X %04X %04X\n",
 			make_flags(r->cc),
 			r->a, r->b, r->x, r->y, r->u, r->s);


### PR DESCRIPTION
A comment in the e6809.c says that register values can have garbage data in the bits above their register size. For example, adding a negative relative offset for the LBRA instruction can set bit 17 of the PC. This has no functional effect except that the disassemly when TRACE_CPU is enabled attempts to disassemble the wrong memory.

The fix here is to mask off the PC with 0xFFFF in the code that prints the disassembly.