### PR TITLE
6821.c: Add parenthesis around conditional.

### DIFF
--- a/6821.c
+++ b/6821.c
@@ -74,7 +74,7 @@ void m6821_calc_cr(struct m6821 *pia)
         pia->ctrl |= M6821_CB2;
         break;
     }
-    if (pia->ctrl |= pia->ctrl_last) {
+    if ((pia->ctrl |= pia->ctrl_last)) {
         m6821_ctrl_change(pia, pia->ctrl);
         pia->ctrl_last = pia->ctrl;
     }


### PR DESCRIPTION
Clang 16.0.0 insists on having another
set of parenthesis around this conditional.