### PR TITLE
Makefile: Ensure `make clean` does remove everything.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 
 CFLAGS = -Wall -pedantic -g3 -Werror
 
-all:	rc2014 rcbus-1802 rcbus-6303 rcbus-6502 rcbus-6509 rcbus-65c816-mini \
+BINS =  rc2014 rcbus-1802 rcbus-6303 rcbus-6502 rcbus-6509 rcbus-65c816-mini \
 	rcbus-65c816 rcbus-6800 rcbus-68008 rcbus-6809 rcbus-68hc11 \
 	rcbus-80c188 rcbus-8085 rcbus-z8 rcbus-z180 rbcv2 searle linc80 \
 	makedisk markiv mbc2 smallz80 sbc2g z80mc simple80 flexbox tiny68k \
 	s100-z80 scelbi rb-mbc rcbus-tms9995 rhyophyre pz1 68knano \
 	littleboard mini68k mb020 pico68 z80retro 2063 z50bus-z80 \
 	trcwm6809 swt6809 nybbles scmp2 sbc08k mini11
+
+all: $(BINS)
 
 sdl2:	rc2014_sdl2 nc100 nc200 n8_sdl2 scelbi_sdl2 nascom uk101 \
 	z180-mini-itx_sdl2 vz300 2063_sdl2 rcbus-8085_sdl2 max80 \
@@ -317,7 +319,7 @@ clean:
 	$(MAKE) --directory m68k clean && \
 	$(MAKE) --directory am9511 clean && \
 	$(MAKE) --directory ns32k clean && \
-	rm -f *.o *~ rc2014 rbcv2
+	rm -f *.o *~ rc2014 rbcv2 $(BINS)
 
 SRCS := $(subst ./,,$(shell find . -name '*.c'))
 DEPDIR := .deps


### PR DESCRIPTION
Previously, it was leaving the executables behind. Alternatively, do you prefer a `make realclean`?