### PR TITLE
Add more support for emulating DUART GPIO pins.

### DIFF
--- a/duart.h
+++ b/duart.h
@@ -15,3 +15,4 @@ extern uint8_t duart_vector(struct duart *duart);
 extern unsigned int next_char(void);
 extern unsigned int check_chario(void);
 extern void recalc_interrupts(void);
+extern void duart_signal_change(struct duart *d, uint8_t opr);

--- a/sbc08k.c
+++ b/sbc08k.c
@@ -222,6 +222,9 @@ int cpu_irq_ack(int level)
 	return M68K_INT_ACK_SPURIOUS;
 }
 
+void duart_signal_change(struct duart *d, uint8_t opr)
+{
+}
 
 /* Read data from RAM, ROM, or a device */
 unsigned int do_cpu_read_byte(unsigned int address)

--- a/tiny68k.c
+++ b/tiny68k.c
@@ -118,8 +118,6 @@ static void rcbus_outb(uint8_t address, uint8_t data)
 {
 }
 
-
-
 int cpu_irq_ack(int level)
 {
 	if (!(irq_pending & (1 << level)))
@@ -129,6 +127,9 @@ int cpu_irq_ack(int level)
 	return M68K_INT_ACK_SPURIOUS;
 }
 
+void duart_signal_change(struct duart *d, uint8_t opr)
+{
+}
 
 /* TODO v2 board added an RTC */
 


### PR DESCRIPTION
At least a couple of systems out there bitbang SD card support via DUART GPIO pins. This commit implements the support required in the DUART code for setting GPIO input pins and a callback for when GPIO output pins change. (It doesn't add any specific SD card bitbang support.)