### PR TITLE
TMS9918a: Attempt to get a border going

### DIFF
--- a/tms9918a.c
+++ b/tms9918a.c
@@ -24,22 +24,6 @@
 
 #include "tms9918a.h"
 
-struct tms9918a {
-    uint8_t reg[8];	/* We just ignore invalid bits, you can't read them
-                           back so who cares */
-    uint8_t status;
-    uint8_t framebuffer[16384];	/* The memory behind the VDP */
-    uint32_t rasterbuffer[256 * 192]; /* Our output texture */
-    uint32_t *colourmap;
-    uint8_t colbuf[256 + 64];	/* For off edge collisions */
-    unsigned int latch;		/* The toggling latch for low/hi */
-    unsigned int read;		/* Mode */
-    uint16_t addr;		/* Address */
-    uint16_t memmask;		/* Address range */
-
-    int trace;
-};
-
 /*
  *	Sprites
  */

--- a/tms9918a.h
+++ b/tms9918a.h
@@ -1,4 +1,18 @@
-struct tms9918a;
+struct tms9918a {
+    uint8_t reg[8];	/* We just ignore invalid bits, you can't read them
+                           back so who cares */
+    uint8_t status;
+    uint8_t framebuffer[16384];	/* The memory behind the VDP */
+    uint32_t rasterbuffer[256 * 192]; /* Our output texture */
+    uint32_t *colourmap;
+    uint8_t colbuf[256 + 64];	/* For off edge collisions */
+    unsigned int latch;		/* The toggling latch for low/hi */
+    unsigned int read;		/* Mode */
+    uint16_t addr;		/* Address */
+    uint16_t memmask;		/* Address range */
+
+    int trace;
+};
 
 extern void tms9918a_rasterize(struct tms9918a *vdp);
 extern void tms9918a_write(struct tms9918a *vdp, uint8_t addr, uint8_t val);

--- a/tms9918a_sdl2.c
+++ b/tms9918a_sdl2.c
@@ -47,13 +47,20 @@ void tms9918a_render(struct tms9918a_renderer *render)
 {
     SDL_Rect sr;
 
-    sr.x = 0;
-    sr.y = 0;
-    sr.w = 256;
-    sr.h = 192;
+    sr.x = 16;
+    sr.y = 12;
+    sr.w = 480;
+    sr.h = 360;
+
+    uint32_t background = render->vdp->colourmap[render->vdp->reg[7] & 0xf];
+    uint8_t a = background >> 24;
+    uint8_t r = background >> 16;
+    uint8_t g = background >> 8;
+    uint8_t b = background & 0xFF;
+    SDL_SetRenderDrawColor(render->render, r, g, b, a);
     SDL_UpdateTexture(render->texture, NULL, tms9918a_get_raster(render->vdp), 1024);
     SDL_RenderClear(render->render);
-    SDL_RenderCopy(render->render, render->texture, NULL, &sr);
+    SDL_RenderCopyEx(render->render, render->texture, NULL, &sr, 0, NULL, SDL_FLIP_NONE);
     SDL_RenderPresent(render->render);
 }
 
@@ -103,7 +110,7 @@ struct tms9918a_renderer *tms9918a_renderer_create(struct tms9918a *vdp)
         exit(1);
     }
     SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "linear");
-    SDL_RenderSetLogicalSize(render->render, 256, 192);
+    SDL_RenderSetLogicalSize(render->render, 512, 384);
 
     render->texture = SDL_CreateTexture(render->render,
                         SDL_PIXELFORMAT_ARGB8888,


### PR DESCRIPTION
This is an attempt to introduce borders.  I went with the SDL2 approach rather than rasterizing the borders and painting a bigger picture.  One of the games I made, changes the border colour for visual feedback so I wanted to include some support for borders in the emulator.

if you would prefer to have the border logic contained in the `tms9918a.c` rasterizer functions, then this is not the PR for you. :-)  I won't be too cut up if it's declined.  But seeing as though I did the work, I wanted to raise the PR.

I couldn't figure out how to get access to the tms9918a struct members without declaring the struct in the header instead of where it's declared now.