### PR TITLE
README_RC2014: CP/M configuration needs pageable rom

### DIFF
--- a/README_RC2014.md
+++ b/README_RC2014.md
@@ -9,7 +9,7 @@ where bank is 0-7 matching the jumpers on the card
 
 ## RC2014 with CP/M
 
-rc2014 -a -r cpm.rom -e bank -i cfdisk.ide
+rc2014 -a -p -r cpm.rom -e bank -i cfdisk.ide
 
 Where bank is the jumpers on the card and and cfdisk.ide is a CP/M disk
 image in IDE emulator format.


### PR DESCRIPTION
Unless I'm mistaken, CP/M on the RC2014 needs either the pageable ROM card `-p` or the 512k RAM/ROM card `-b`.

I've updated the README to use `-p` for the first variant. Previously, these instructions half-booted but crashed before reaching the `A>` prompt.