### PR TITLE
Fix off by one on sprite vertical position.

### DIFF
--- a/tms9918a.c
+++ b/tms9918a.c
@@ -51,6 +51,7 @@ struct tms9918a {
  */
 static void tms9918a_render_slice(struct tms9918a *vdp, int y, uint8_t *sprat, uint16_t bits, unsigned int width)
 {
+	y += 1;
 	int x = sprat[1];
 	uint32_t *pixptr = vdp->rasterbuffer + 256 * y;
 	uint8_t *colptr = vdp->colbuf + 32;


### PR DESCRIPTION
The TMS9918a considers the top row of sprites to begin being visible at Y=-1. (0xFF).  This change compensates for that.

When I updated my game to position sprites accordingly, they were all rendered correctly on real hardware and rendered incorrectly on the emulator.  Specifically, on the emulator, sprites appeared 1 pixel too high.

This PR simply increments the Y value of the sprite in the sprite slice routine to compensate for the strange (yet documented) behavior of the TMS9918A VDP.