### PR TITLE
Bug/memory overflow

### DIFF
--- a/tms9918a.c
+++ b/tms9918a.c
@@ -29,7 +29,7 @@ struct tms9918a {
 			   back so who cares */
 	uint8_t status;
 	uint8_t framebuffer[16384];	/* The memory behind the VDP */
-	uint32_t rasterbuffer[256 * 192]; /* Our output texture */
+	uint32_t rasterbuffer[256 * 256]; /* Our output texture allow partially signed Y */
 	uint32_t *colourmap;
 	uint8_t colbuf[256 + 64];	/* For off edge collisions */
 	unsigned int latch;		/* The toggling latch for low/hi */


### PR DESCRIPTION
I struggled with this one.

First change is to increase the depth of the rasterbuffer to allow all the Y positions to be plotted - even those not drawn.

Second change is to more carefully calculate the sprite Y position based on the partial signedness of the Y value for a sprite. 

I had to borrow from the https://github.com/visrealm/vrEmuTms9918 project for the specific details.  While not a direct copy paste, there is some of Troy's magic in there.